### PR TITLE
feat(controller): Create GitHub check for taskRuns

### DIFF
--- a/manifests/base/tasks/run.yaml
+++ b/manifests/base/tasks/run.yaml
@@ -10,6 +10,8 @@ spec:
       default: ".github"
     - name: SECRET_NAME
       type: string
+    - name: CHECK_RUN_ID
+      type: string
   steps:
     - name: apply-peribolos
       image: toolbox
@@ -22,8 +24,20 @@ spec:
             secretKeyRef:
               name: $(params.SECRET_NAME)
               key: orgName
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: $(params.SECRET_NAME)
+              key: token
       script: |
         #!/usr/bin/bash
+
+        echo "Updating check run to in-progress..."
+        curl -X PATCH \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer $GITHUB_TOKEN" \
+          https://api.github.com/repos/$ORG_NAME/.github/check-runs/$(params.CHECK_RUN_ID) \
+          -d '{"status":"in_progress"}'
 
         echo "Cloning repository..."
         # Clone repository
@@ -31,8 +45,22 @@ spec:
         cd $(params.REPO_NAME)
 
         # Run Peribolos on the repository
-        echo "Running peribolos..."
+        echo "Running peribolos on commit $(git rev-parse --short HEAD)..."
         peribolos --config-path peribolos.yaml --github-token-path /mnt/secret/token --fix-org --fix-repos --fix-team-members --fix-teams --fix-team-repos --confirm
+
+        if [ $? -eq 0 ]; then
+          CONCLUSION="success"
+        else
+          CONCLUSION="failure"
+        fi
+
+        echo "Updating check run to completed with $CONCLUSION..."
+        curl -X PATCH \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: Bearer $GITHUB_TOKEN" \
+          https://api.github.com/repos/$ORG_NAME/.github/check-runs/$(params.CHECK_RUN_ID) \
+          -d "{\"status\":\"completed\",\"conclusion\":\"$CONCLUSION\"}"
+
   volumes:
     - name: github-token
       secret:

--- a/manifests/base/tasks/run.yaml
+++ b/manifests/base/tasks/run.yaml
@@ -41,7 +41,7 @@ spec:
 
         echo "Cloning repository..."
         # Clone repository
-        git clone https://github.com/$ORG_NAME/$(params.REPO_NAME)
+        git clone https://x-access-token:$GITHUB_TOKEN@github.com/$ORG_NAME/$(params.REPO_NAME)
         cd $(params.REPO_NAME)
 
         # Run Peribolos on the repository


### PR DESCRIPTION
Resolves #63
Resolves #51

A GitHub [check](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks) is created whenever a `taskRun` is created. The user can then re-run the `task` via the check `re-run` button. The checks are created only if the push contains a change in `peribolos.yaml` config, if more commits are pushed at the same time the check runs only on the most recent commit.
