### PR TITLE
feat: Specify minimum number of org admins

### DIFF
--- a/manifests/base/tasks/run.yaml
+++ b/manifests/base/tasks/run.yaml
@@ -51,7 +51,7 @@ spec:
 
         # Run Peribolos on the repository
         echo "Running peribolos on commit $(git rev-parse --short HEAD)..."
-        peribolos --config-path peribolos.yaml --github-app-id $APP_ID --github-app-private-key-path /mnt/secret/private_key --fix-org --fix-org-members --fix-repos --fix-team-members --fix-teams --fix-team-repos --confirm
+        peribolos --config-path peribolos.yaml --github-app-id $APP_ID --github-app-private-key-path /mnt/secret/private_key --fix-org --fix-org-members --min-admins=2 --fix-repos --fix-team-members --fix-teams --fix-team-repos --confirm
 
         if [ $? -eq 0 ]; then
           CONCLUSION="success"


### PR DESCRIPTION
The default configuration of peribolos requires 5 admins be specified. This change reduces the required number to 2