### PR TITLE
fix: set --require-self to false on peribolos-run task

### DIFF
--- a/manifests/base/tasks/run.yaml
+++ b/manifests/base/tasks/run.yaml
@@ -51,7 +51,7 @@ spec:
 
         # Run Peribolos on the repository
         echo "Running peribolos on commit $(git rev-parse --short HEAD)..."
-        peribolos --config-path peribolos.yaml --github-app-id $APP_ID --github-app-private-key-path /mnt/secret/private_key --fix-org --fix-org-members --min-admins=2 --fix-repos --fix-team-members --fix-teams --fix-team-repos --confirm
+        peribolos --config-path peribolos.yaml --github-app-id $APP_ID --github-app-private-key-path /mnt/secret/private_key --fix-org --fix-org-members --min-admins=2 --fix-repos --fix-team-members --fix-teams --fix-team-repos --confirm --require-self=false
 
         if [ $? -eq 0 ]; then
           CONCLUSION="success"


### PR DESCRIPTION
For an unknown reason peribolos run now requires app to be listed in the org... This results in run failures.