### PR TITLE
fix: Renew credentials on check retry

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -257,6 +257,12 @@ export default (
       return;
     }
 
+    // Update token in case it expired
+    await wrapOperationWithMetrics(updateTokenSecret(context), {
+      install: context.payload.installation.id,
+      method: 'updateSecret',
+    });
+
     context.octokit.checks.update({
       owner: context.payload.organization.login,
       repo: '.github',


### PR DESCRIPTION
Requesting reruns after the token expires doesn't renew creds. This should fix it.